### PR TITLE
Added support for binding to the slick init event

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -131,7 +131,7 @@ gulp.task('rollup:umd', function () {
       // The name to use for the module for UMD/IIFE bundles
       // (required for bundles with exports)
       // See https://github.com/rollup/rollup/wiki/JavaScript-API#modulename
-      moduleName: 'ngx-slick',
+      name: 'ngx-slick',
 
       // See https://github.com/rollup/rollup/wiki/JavaScript-API#globals
       globals: {

--- a/src/slick.component.ts
+++ b/src/slick.component.ts
@@ -28,6 +28,7 @@ export class SlickComponent implements AfterViewInit, OnDestroy {
     @Output() beforeChange: EventEmitter<any> = new EventEmitter();
     @Output() breakpoint: EventEmitter<any> = new EventEmitter();
     @Output() destroy: EventEmitter<any> = new EventEmitter();
+    @Output() init: EventEmitter<any> = new EventEmitter();
 
     public slides: any = [];
     public $instance: any;
@@ -60,7 +61,17 @@ export class SlickComponent implements AfterViewInit, OnDestroy {
         const self = this;
 
         this.zone.runOutsideAngular(() => {
-            this.$instance = $(this.el.nativeElement).slick(this.config);
+
+            this.$instance = $(this.el.nativeElement);
+
+            this.$instance.on('init', (event, slick) => {
+                self.zone.run(() => {
+                    self.init.emit({event, slick});
+                });
+            });
+            
+            this.$instance.slick(this.config);
+
             this.initialized = true;
 
             this.$instance.on('afterChange', (event, slick, currentSlide) => {
@@ -107,6 +118,7 @@ export class SlickComponent implements AfterViewInit, OnDestroy {
     /**
      * Slick Method
      */
+
     public slickGoTo(index: number) {
         this.zone.run(() => {
             this.$instance.slick('slickGoTo', index);


### PR DESCRIPTION
Added support for binding to slick init event. 
updated the 'moduleName' to use the new syntax 'name' for module naming 
more info https://github.com/jvandemo/generator-angular2-library/issues/195
