### PR TITLE
Clear out contents of carousel on re-init

### DIFF
--- a/src/slick.component.ts
+++ b/src/slick.component.ts
@@ -60,6 +60,7 @@ export class SlickComponent implements AfterViewInit, OnDestroy {
         const self = this;
 
         this.zone.runOutsideAngular(() => {
+            $(_this.el.nativeElement)[0].innerHTML = "";
             this.$instance = $(this.el.nativeElement).slick(this.config);
             this.initialized = true;
 


### PR DESCRIPTION
We ran into an issue where navigating away from and then back to the page containing the carousel resulted in additional sliders being added to the beginning of the rotation, containing nothing but empty divs.  After much troubleshooting, it looks like it's being caused by old html from previous loads of the component sticking around and being turned into slides at initialization, which are then proceeded by the actual slides added after initialization.  This clears out the control before init so the leftover html doesn't interfere and you get a clean load every time.