### PR TITLE
fix: Cannot read property 'slick' of undefined issue when navigating

### DIFF
--- a/src/slick.component.ts
+++ b/src/slick.component.ts
@@ -154,7 +154,9 @@ export class SlickComponent implements AfterViewInit, OnDestroy {
 
     public unslick() {
         this.zone.run(() => {
-            this.$instance.slick('unslick');
+        	if (this.$instance) {
+	            this.$instance.slick('unslick');        		
+        	}
         });
     }
 


### PR DESCRIPTION
Hi @devmark It's related with this issue - https://github.com/devmark/ngx-slick/issues/6